### PR TITLE
NNTrainer Proposal

### DIFF
--- a/proposals/nntrainer.adoc
+++ b/proposals/nntrainer.adoc
@@ -1,0 +1,137 @@
+== NNTrainer Project Proposal
+
+
+*Name of the project*: NNTrainer
+
+*Requested maturity level*: Sandbox stage
+
+*Description*:
+NNTrainer is a software framework to train neural network models in embedded devices, which have relatively limited resources.
+Usually, but not necessarily, NNTrainer trains a pre-trained model for personalization; e.g., fine-tuning a base common model with additional data of a user.
+However, it can still train a model from scratch as conventional frameworks do.
+
+
+NNTrainer promotes easier and efficient development of on-device AI training and personalization with its API sets (C/C\+\+/C\#/Web) and features targetting on-device AI personalization usage scenarios.
+For the embedded devices with limited resources, NNTrainer provides highly efficient (both memory and computation) mechanisms as described in a https://arxiv.org/abs/2206.04688[tech report].
+NNTrainer is highly modular and extensible; thus, users can extend its functions with their own implementation, deployed as plugins.
+
+
+NNTrainer has started as an open source project since 2019 with Apache 2.0 license.
+NNTrainer is released for Tizen, Ubuntu, and Android and tested daily for them.
+And it is already being deployed for a few consumer electronic devices, from mobile devices to home appliances.
+
+
+NNTrainer is a spun-off project from another LF AI & Data project, https://nntrainer.ci[NNStreamer].
+
+
+More information is available at
+
+ * https://github.com/nnstreamer/nntrainer[Github repo] (The main NNTrainer page)
+ * https://arxiv.org/abs/2206.04688[Arxiv article] (2022.6.) "NNTrainer: Light-Weight On-Device Training Framework"
+ * https://www.youtube.com/watch?v=HKKowY78P1[SDC 21' presentation] (2021.10.) "[Tech Talk] NNTrainer: Personalize neural networks on devices!"
+ * https://www.youtube.com/watch?v=HWiV7WbIM3E&t=48s[SSDC 21' presentation] (2021.11.) (Korean)
+
+
+*Statement on alignment with LF AI’s mission:* NNTrainer allows training, fine-tuning, personalizing, or updating nerual network models in light-weight deviecs (such as mobile phones, televisions, and home appliances) with mechanisms specialized in on-device AI & AI personalization usage scenarios. NNTrainer offers such mechanisms as open source software and promotes usages and contributions of the general public.
+
+
+*Have you identified possible collaboration opportunities with current LF AI hosted projects (https://lfai.foundation/projects/)? Please explain.*:
+
+ * Pravega (LF): we are considering Pravega as a candidate data repository for stream pipelined on-device training. Pravega is considering NNStreamer as its extension as well.
+ * Sparklyr: this may be an alternative choice for the data repository.
+ * ONNX: NNTrainer is going to support importing from and exporting to model file formats of other frameworks. The first candidates are .circle (One runtime) and .tflite (Tensorflow-lite). Unless .circle supports import/export with ONNX, ONNX will be the second candidate.
+ * NNStreamer: NNStreamer can offer streaming capability for NNTrainer with its https://github.com/nnstreamer/nnstreamer/issues/3745[future feature]. They share the same https://github.com/nnstreamer/API[API infrastructure], which will provide remote off-loading inferences and training.
+
+
+*License*: https://github.com/nnstreamer/nntrainer/blob/main/LICENSE[Apache 2.0]
+
+*Source control*: https://github.com/nnstreamer/nntrainer[Github]
+
+*Github organization*: sharing https://github.com/nnstreamer[NNStreamer organization] with NNStreamer project.
+
+*Github DCO*: active with its pull requests.
+
+*Issue tracker*: https://github.com/nnstreamer/nntrainer/issues[Github Issues]
+
+*Collaboration tools*: https://github.com/nnstreamer/nntrainer/issues[Github Issues], https://github.com/nnstreamer/nntrainer/discussions[Github Discussions]
+
+*External dependencies*:
+
+ * Mandatory Dependencies
+ ** Meson (Apache 2.0)
+ ** Openblas (BSD-3)
+ ** Iniparser (MIT)
+
+ * Optional Dependencies
+ ** FlatBuffers (Apache 2.0)
+ ** GTest (BSD-3)
+ ** Python >= 3 (PSF)
+ ** SSAT (Apache 2.0)
+ ** gym-http-api (MIT)
+ ** lcov (GPL 2.0)
+ ** OpenCV (Apache 2.0)
+ ** DLOG (Apache 2.0, MIT)
+ ** Tensorflow-lite >= 2 (Apache 2.0)
+ ** NNStreamer (LGPL 2.1)
+ ** GStreamer (LGPL 2.1)
+
+*Initial committers*:
+
+ ** Jijoong Moon, jijoong.moon@samsung.com, Samsung Research, since 2019.10.
+ ** Hyeonseok Lee, hs89.lee@samsung.com, Samsung Research, since 2020.4.
+ ** Hyunil Park, hyunil46.park@samsung.com, Samsung Research, since 2022.3.
+ ** Jiho Chu, jiho.chu@samsung.com, Samsung Research, 2022.4.
+ ** Donghak Park, donghak.park@samsung.com, Samsung Research, 2022.5.
+ ** Parichay Kapoor, kparichay@gmail.com, Meta (since 2022), since 2020.6.
+ ** Jihoon Lee, zhoonit@gmail.com, NHN (since 2022), since 2020.4.
+ ** MyungJoo Ham, myungjoo.ham@samsung.com, Samsung Research, since 2021.1.
+ ** Sangjung Woo, sangjung.woo@samsung.com, Samsung Research, since 2020.5.
+
+
+ ** Seongwoo Chae, mhs4670go@naver.com, Samsung Research, since 2022.5.
+ ** Dongju Chae, dongju.chae@samsung.com, Samsung Research, since 2020.5.
+ ** Juyeong Lee, judy.lee@daangn.com, Danggeun Market Inc., since 2021.2.
+ ** Wook Song, wook16.song@samsung.com, Samsung Research, since 2020.3.
+ ** Gichan Jang, gichan2.jang@samsung.com, Samsung Research, since 2021.1.
+ ** Jaeyun Jung, jy1210.jung@samsung.com, Samsung Research, since 2021.2.
+ ** Mete Ozay, meteozay@gmail.com, Samsung Research UK, since 2020.11.
+ ** Yongjoo Ahn, yongjoo1.ahn@samsung.com, Samsung Research, since 2020.10.
+ ** Geunsik Lim, geunsik.lim@samsung.com, Samsung Research, since 2020.5.
+ ** JeanSanghyun, brainer@kakao.com, Unknown, since 2020.7.
+ ** Udit Jain, udit.jain@samsung.com, Samsung Research, since 2022.5.
+
+
+
+*The roles of contributor, committer, maintainer, etc.*: https://github.com/nnstreamer/nntrainer/blob/main/MAINTAINERS.md[MAINTAINERS.md]
+
+*Total number of contributors to the project including their affiliations.*:
+
+Counting code commits only.
+
+* Samsung Research: 5 (highly active) 10 (casual)
+* Samsung Research UK: 1 (casual)
+* Meta UK: 1 (highly active --> casual. ex-Samsung)
+* NHN: 1 (highly active --> casual. ex-Samsung)
+* Danggeun Market Inc.: 1 (cacual)
+* Unknown: 1
+
+*Release methodology*: https://github.com/nnstreamer/nntrainer/blob/main/RELEASE.md[RELEASES.md]
+
+*Code of conduct*: https://github.com/nnstreamer/nntrainer/blob/main/CODE_OF_CONDUCT.md[CODE_OF_CONDUCT.md]
+
+*CII best practices badges*: No.
+
+*Do you have any specific infrastructure requests needed as part of hosting the project in the LF AI?*: No, nntrainer shares infra with nnstreamer.
+
+*Project website*:
+
+ * We do not have a web site other than out https://github.com/nnstreamer/nntrainer[Github main]
+ * We do not have a domain reserved.
+ * We would like to have one; e.g., nntrainer.ai
+
+*Project governance*: https://github.com/nnstreamer/nntrainer/blob/main/CONTRIBUTING.md[CONTRIBUTING.md]
+
+*Social media accounts*: None. for now, we are sharing nnstreamer's.
+
+*Existing sponsorship*: Samsung Research, Samsung (LF Platinum member)
+


### PR DESCRIPTION
NNTrainer is a neural network training framework for embedded devices.
NNTrainer is a spun-off project of another LF AI&Data project, NNStreamer.

CC: @jijoongmoon @lhs8928 @songgot @DonghakPark @jihochu : please take a look and review.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>